### PR TITLE
refactor: reposition useTheme hook to inside hooks folder

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 
 type Theme = "dark" | "light" | "system";
 
@@ -18,7 +18,8 @@ const initialState: ThemeProviderState = {
   setTheme: () => null,
 };
 
-const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
+export const ThemeProviderContext =
+  createContext<ThemeProviderState>(initialState);
 
 export function ThemeProvider({
   children,
@@ -60,12 +61,3 @@ export function ThemeProvider({
     </ThemeProviderContext.Provider>
   );
 }
-
-export const useTheme = () => {
-  const context = useContext(ThemeProviderContext);
-
-  if (context === undefined)
-    throw new Error("useTheme must be used within a ThemeProvider");
-
-  return context;
-};

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,5 +1,5 @@
 import { Moon, Sun } from "lucide-react";
-import { useTheme } from "@/components/theme-provider";
+import { useTheme } from "@/hooks/use-theme";
 import { Button } from "@/components/ui/button";
 
 export function ThemeToggle() {

--- a/src/hooks/use-theme.tsx
+++ b/src/hooks/use-theme.tsx
@@ -1,0 +1,11 @@
+import { ThemeProviderContext } from "@/components/theme-provider";
+import { useContext } from "react";
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext);
+
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider");
+
+  return context;
+};


### PR DESCRIPTION
# Reposition useTheme hook to hooks folder

## Description
This PR moves the `useTheme` hook from the `components` folder to the `hooks` folder, improving our project structure and making it easier to locate and manage custom hooks.

## Changes
- Move `useTheme` hook from `src/components/theme-provider.tsx` to `src/hooks/use-theme.ts`
- Update imports in affected files

## File changes